### PR TITLE
Allowing a user defined debug function to be passed, or debug to not be used at all

### DIFF
--- a/lib/HylafaxClient.js
+++ b/lib/HylafaxClient.js
@@ -18,9 +18,21 @@ function HylafaxClient(params){
   self.username = params.username || '';
   self.password = params.password || '';
 
+  if(params.debug !== undefined) {
+    if(typeof params.debug == 'function') {
+      self.debug = params.debug;
+    } else if (params.debug == false) {
+      self.debug = function(debug) {  };
+    } else {
+      self.debug = function(debug) { console.log(debug) };
+    }
+  } else {
+    self.debug = function(debug) { console.log(debug) };
+  }
+
   //http://www.hylafax.org/man/6.0/hfaxd.1m.html
   //going to use the send functionality in this module and it's callback methodology
-  self.ftp = new FTPClient({ host: self.host, port: self.port, debug: function(debug){console.log(debug)} });
+  self.ftp = new FTPClient({ host: self.host, port: self.port, debug: self.debug });
   self.ftp.on('connect', function() {
     self.ftp.send('USER', self.username, function(err, res){
       if(self.password != ''){


### PR DESCRIPTION
Ftp.js allows us to define a debug function, instead of simply defaulting this, why not let a function be passed to HylafaxClient like port or host. this way we can have our own function for getting the debug, or declare it false to not have any at all.
